### PR TITLE
Consola config

### DIFF
--- a/src/server/plugins/logger.ts
+++ b/src/server/plugins/logger.ts
@@ -2,7 +2,6 @@ import consola from 'consola'
 
 function getDynamicTag(){
   const timestamp = new Date().toISOString() // Get the current timestamp
-    
      // Construct the log message
     return  `vidur [${timestamp}]`
 

--- a/src/server/plugins/logger.ts
+++ b/src/server/plugins/logger.ts
@@ -1,0 +1,18 @@
+import consola from 'consola'
+
+function getDynamicTag(){
+  const timestamp = new Date().toISOString() // Get the current timestamp
+    
+     // Construct the log message
+    return  `vidur [${timestamp}]`
+
+}
+// Create and configure the logger
+const logger = consola.create({
+  level: process.env.NODE_ENV === 'production' ? 4 : 3 // Set log level based on environment
+}).withTag(getDynamicTag())
+
+
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.logger = logger
+})

--- a/src/types/nitro.d.ts
+++ b/src/types/nitro.d.ts
@@ -1,0 +1,10 @@
+// types/nitro.d.ts
+
+import 'nitropack'
+import consola from 'consola'
+
+declare module 'nitropack' {
+  interface NitroApp {
+    logger: typeof consola
+  }
+}


### PR DESCRIPTION
Ingesting logger plugin. utils/logger.ts https://github.com/profilecity/vidur/issues/61

To use the logger in server side files, import the logger from Nitropack and log messages.
Every time a message is logged, the line will begin with the app name and timestamp.