### PR TITLE
Reduce docker image size with mutli-stage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.6-alpine
+FROM node:22.6-alpine AS build
 
 WORKDIR /app
 
@@ -6,5 +6,15 @@ COPY package.json yarn.lock ./
 
 RUN --mount=type=cache,target=/root/.cache/yarn \
     yarn install
+
+# stage 2
+
+FROM node:22.6-alpine
+
+WORKDIR /app
+
+COPY --from=build /app /app
+
+EXPOSE 3001
 
 CMD ["sh", "-c", "yarn migration:apply && yarn dev"]


### PR DESCRIPTION
Docker mutli-stage docker build will help to reduce docker image size.

> You can see what we have previously

Size of postgres image is 400mb
Size of Vidur codebase including node modules is 200mb
But, size of docker image: 2.4GB!!??

and, what we have now
```shell
PS C:\Users\shivam sharma\Desktop\My Project\open-source\vidur> docker image ls 
REPOSITORY   TAG           IMAGE ID       CREATED          SIZE
vidur-app    latest        f61fb1b47135   12 minutes ago   399MB
```
fixes: #100  
