### PR TITLE
fix typo:   `description` instead `decrition` in seo frame input

### DIFF
--- a/app/components/admin/SeoFrame.vue
+++ b/app/components/admin/SeoFrame.vue
@@ -54,7 +54,7 @@ const onSubmit = handleSubmit(async (values) => {
           />
           <InputText
             class="w-full md:w-1/2"
-            placeholder="Big Space Career Site Decrition"
+            placeholder="Big Space Career Site Description"
             v-model="description"
             id="seo-description"
             :error="errors['description']"


### PR DESCRIPTION
Typo: `decrition` instead `description` in seo frame input

fixes: #132