### PR TITLE
seed-cache-review-tags-api

### DIFF
--- a/server/api/review-tags/index.get.ts
+++ b/server/api/review-tags/index.get.ts
@@ -1,21 +1,10 @@
-// Import the defineEventHandler function from the 'h3' package
-// This is used to create server-side event handlers
-import { defineEventHandler } from 'h3';
-import { type ReviewTag } from '../../db/schema'; //import review tags from db schema
-
+import { type ReviewTag } from '../../db/schema';
 import authenticateAdminRequest from '../../utils/admin';
 
-// Define and export the default event handler for this API endpoint
 export default defineEventHandler(async (event) => {
-  // Authenticate the request to ensure it's coming from an admin
-  // This function should throw an error if authentication fails
-
   await authenticateAdminRequest(event);
 
-  //RetreiveTags from general memory storage and
-  //If no tags are found, default to an empty array
   const reviewTags = (await general_memoryStorage.getItem<ReviewTag[]>('reviewTags')) || [];
 
-  //Return the review tags as the response
   return reviewTags;
 });

--- a/server/api/review-tags/index.get.ts
+++ b/server/api/review-tags/index.get.ts
@@ -1,0 +1,21 @@
+// Import the defineEventHandler function from the 'h3' package
+// This is used to create server-side event handlers
+import { defineEventHandler } from 'h3';
+import { type ReviewTag } from '../../db/schema'; //import review tags from db schema
+
+import authenticateAdminRequest from '../../utils/admin';
+
+// Define and export the default event handler for this API endpoint
+export default defineEventHandler(async (event) => {
+  // Authenticate the request to ensure it's coming from an admin
+  // This function should throw an error if authentication fails
+
+  await authenticateAdminRequest(event);
+
+  //RetreiveTags from general memory storage and
+  //If no tags are found, default to an empty array
+  const reviewTags = (await general_memoryStorage.getItem<ReviewTag[]>('reviewTags')) || [];
+
+  //Return the review tags as the response
+  return reviewTags;
+});

--- a/server/api/review-tags/index.get.ts
+++ b/server/api/review-tags/index.get.ts
@@ -1,5 +1,4 @@
 import { type ReviewTag } from '../../db/schema';
-import authenticateAdminRequest from '../../utils/admin';
 
 export default defineEventHandler(async (event) => {
   await authenticateAdminRequest(event);

--- a/server/api/review-tags/index.get.ts
+++ b/server/api/review-tags/index.get.ts
@@ -1,4 +1,5 @@
 import { type ReviewTag } from '../../db/schema';
+import authenticateAdminRequest from '../../utils/admin';
 
 export default defineEventHandler(async (event) => {
   await authenticateAdminRequest(event);

--- a/server/utils/tasks/seed-cache.ts
+++ b/server/utils/tasks/seed-cache.ts
@@ -1,5 +1,5 @@
 import { desc, inArray } from 'drizzle-orm';
-import { jobPostingsTable, metaDataTable } from '~~/server/db/schema';
+import { jobPostingsTable, reviewTagsTable, metaDataTable } from '~~/server/db/schema'; //import the review tags table from schema
 import type { CareerSiteConfig, SEOConfig } from '~~/shared/schemas/setting';
 
 export async function seedCache() {
@@ -11,6 +11,10 @@ export async function seedCache() {
     .select()
     .from(metaDataTable)
     .where(inArray(metaDataTable.key, ['seoConfig', 'careerSiteConfig', 'firstSetupAccessKey']));
+
+  //getting the review tags from the reviewTagsTable
+  const reviewTags = await db.select().from(reviewTagsTable);
+  console.log(reviewTags); //debug to check the reviewtags response
 
   // Do not save totalApplicants in cache
   const jobPostings = (await db.select().from(jobPostingsTable).orderBy(desc(jobPostingsTable.createdAt))).map((p) => ({
@@ -41,6 +45,7 @@ export async function seedCache() {
     general_memoryStorage.setItem('firstSetupAccessKey', firstSetupAccessKey),
     general_memoryStorage.setItem('remoteAssetBase', remoteAssetBase),
     general_memoryStorage.setItem('postings', jobPostings),
+    general_memoryStorage.setItem('reviewTags', reviewTags), //setting the reviewTags to general_memorystorage
   ]);
 
   return { result: true };

--- a/server/utils/tasks/seed-cache.ts
+++ b/server/utils/tasks/seed-cache.ts
@@ -12,9 +12,7 @@ export async function seedCache() {
     .from(metaDataTable)
     .where(inArray(metaDataTable.key, ['seoConfig', 'careerSiteConfig', 'firstSetupAccessKey']));
 
-  //getting the review tags from the reviewTagsTable
   const reviewTags = await db.select().from(reviewTagsTable);
-  console.log(reviewTags); //debug to check the reviewtags response
 
   // Do not save totalApplicants in cache
   const jobPostings = (await db.select().from(jobPostingsTable).orderBy(desc(jobPostingsTable.createdAt))).map((p) => ({
@@ -45,7 +43,7 @@ export async function seedCache() {
     general_memoryStorage.setItem('firstSetupAccessKey', firstSetupAccessKey),
     general_memoryStorage.setItem('remoteAssetBase', remoteAssetBase),
     general_memoryStorage.setItem('postings', jobPostings),
-    general_memoryStorage.setItem('reviewTags', reviewTags), //setting the reviewTags to general_memorystorage
+    general_memoryStorage.setItem('reviewTags', reviewTags),
   ]);
 
   return { result: true };

--- a/server/utils/tasks/seed-cache.ts
+++ b/server/utils/tasks/seed-cache.ts
@@ -1,5 +1,5 @@
 import { desc, inArray } from 'drizzle-orm';
-import { jobPostingsTable, reviewTagsTable, metaDataTable } from '~~/server/db/schema'; //import the review tags table from schema
+import { jobPostingsTable, reviewTagsTable, metaDataTable } from '~~/server/db/schema';
 import type { CareerSiteConfig, SEOConfig } from '~~/shared/schemas/setting';
 
 export async function seedCache() {


### PR DESCRIPTION
## Seed Cache Update and Review-tags api 

- Updated the seed cache to load the review tags from the database schema
- Updated general memory storage to store review tags
- Implements new API endpoint for retrieving review tags
- Secures endpoint with admin authentication
- Fetches review tags from application's memory storage
- Returns array of ReviewTag objects matching database schema
- Enables efficient access to review tags for admin users

Resolved #151 