### PR TITLE
total-positions-addition-public-config-api-UI

### DIFF
--- a/app/components/Ui/Tag.vue
+++ b/app/components/Ui/Tag.vue
@@ -1,0 +1,5 @@
+<template>
+  <span class="bg-blue-100 px-2 py-1 border border-blue-300 rounded-lg text-blue-700 text-sm">
+    <slot />
+  </span>
+</template>

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -13,7 +13,7 @@ export function useOnboardingStatusState() {
   return useState<boolean>('onboarding-status', () => false);
 }
 
-export function usePositionState() {
+export function useTotalPositionsState() {
   return useState<number>('totalPositions', () => 0);
 }
 

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -14,7 +14,7 @@ export function useOnboardingStatusState() {
 }
 
 export function useTotalActivePostingsState() {
-  return useState<number>('totalPositions', () => 0);
+  return useState<number>('total-active-postings', () => 0);
 }
 
 export function useCareerSiteConfigObjectState() {

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -13,7 +13,7 @@ export function useOnboardingStatusState() {
   return useState<boolean>('onboarding-status', () => false);
 }
 
-export function useTotalPositionsState() {
+export function useTotalActivePostingsState() {
   return useState<number>('totalPositions', () => 0);
 }
 

--- a/app/composables/state.ts
+++ b/app/composables/state.ts
@@ -13,6 +13,10 @@ export function useOnboardingStatusState() {
   return useState<boolean>('onboarding-status', () => false);
 }
 
+export function usePositionState() {
+  return useState<number>('totalPositions', () => 0);
+}
+
 export function useCareerSiteConfigObjectState() {
   return useObjectState<CareerSiteConfig>('career-site-config');
 }

--- a/app/pages/admin/applications.vue
+++ b/app/pages/admin/applications.vue
@@ -58,9 +58,7 @@ watchEffect(() => {
           <span class="font-noto font-bold mr-2">
             {{ postingsById[posting] || '' }}
           </span>
-          <span class="bg-blue-100 px-2 py-1 border border-blue-300 rounded-lg text-blue-700 text-sm">
-            {{ applications[posting]?.length }} Applicants
-          </span>
+          <UiTag> {{ applications[posting]?.length }} Applicants </UiTag>
         </div>
         <div class="text-sm">
           <AdminApplicationRow

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -42,8 +42,8 @@ useSeoMeta({
   <main class="grow w-full lg:w-2/3 mx-auto mt-20 p-2">
     <SiteHeader />
     <h3 class="text-lg leading-snug text-zinc-600 font-bold mt-8 mb-2">
-      Open Positions
-      <span class="text-sm text-zinc-500 before:content-['('] after:content-[')']">>{{ totalPositions }}</span>
+      Open Applicants
+      <span class="text-sm text-zinc-500 before:content-['('] after:content-[')']">{{ totalPositions }}</span>
     </h3>
     <div class="space-y-2" v-if="postings">
       <PostingCard v-for="posting in postings" :key="posting.id" :posting="posting" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,7 +2,7 @@
 const { data: postings } = await usePublicPostingsRepository();
 const { data: careerSiteConfig } = useCareerSiteConfigObjectState();
 const { data: seoConfig } = useSeoConfigObjectState();
-const totalPositions = useTotalPositionsState();
+const totalActivePostings = useTotalActivePostingsState();
 const publicConfig = useRuntimeConfig().public;
 
 let title: string = 'Careers'; // TODO: need better defaults (this will hardly be the case);
@@ -42,8 +42,8 @@ useSeoMeta({
   <main class="grow w-full lg:w-2/3 mx-auto mt-20 p-2">
     <SiteHeader />
     <h3 class="text-lg leading-snug text-zinc-600 font-bold mt-8 mb-2">
-      Open Applicants
-      <span class="text-sm text-zinc-500 before:content-['('] after:content-[')']">{{ totalPositions }}</span>
+      Open Positions
+      <span class="text-sm text-zinc-500]">({{ totalActivePostings }})</span>
     </h3>
     <div class="space-y-2" v-if="postings">
       <PostingCard v-for="posting in postings" :key="posting.id" :posting="posting" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -43,7 +43,7 @@ useSeoMeta({
     <SiteHeader />
     <h3 class="text-lg leading-snug text-zinc-600 font-bold mt-8 mb-2">
       Open Positions
-      <span class="text-sm text-zinc-500]">({{ totalActivePostings }})</span>
+      <UiTag>{{ totalActivePostings }}</UiTag>
     </h3>
     <div class="space-y-2" v-if="postings">
       <PostingCard v-for="posting in postings" :key="posting.id" :posting="posting" />

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,7 +2,7 @@
 const { data: postings } = await usePublicPostingsRepository();
 const { data: careerSiteConfig } = useCareerSiteConfigObjectState();
 const { data: seoConfig } = useSeoConfigObjectState();
-const totalPositions = usePositionState();
+const totalPositions = useTotalPositionsState();
 const publicConfig = useRuntimeConfig().public;
 
 let title: string = 'Careers'; // TODO: need better defaults (this will hardly be the case);

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -41,8 +41,10 @@ useSeoMeta({
 <template>
   <main class="grow w-full lg:w-2/3 mx-auto mt-20 p-2">
     <SiteHeader />
-    <h3 class="text-lg leading-snug text-zinc-600 font-bold mt-8 mb-2">Open Positions</h3>
-    <span class="text-sm text-zinc-500">({{ totalPositions }})</span>
+    <h3 class="text-lg leading-snug text-zinc-600 font-bold mt-8 mb-2">
+      Open Positions
+      <span class="text-sm text-zinc-500 before:content-['('] after:content-[')']">>{{ totalPositions }}</span>
+    </h3>
     <div class="space-y-2" v-if="postings">
       <PostingCard v-for="posting in postings" :key="posting.id" :posting="posting" />
     </div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -2,7 +2,7 @@
 const { data: postings } = await usePublicPostingsRepository();
 const { data: careerSiteConfig } = useCareerSiteConfigObjectState();
 const { data: seoConfig } = useSeoConfigObjectState();
-
+const totalPositions = usePositionState();
 const publicConfig = useRuntimeConfig().public;
 
 let title: string = 'Careers'; // TODO: need better defaults (this will hardly be the case);
@@ -42,6 +42,7 @@ useSeoMeta({
   <main class="grow w-full lg:w-2/3 mx-auto mt-20 p-2">
     <SiteHeader />
     <h3 class="text-lg leading-snug text-zinc-600 font-bold mt-8 mb-2">Open Positions</h3>
+    <span class="text-sm text-zinc-500">({{ totalPositions }})</span>
     <div class="space-y-2" v-if="postings">
       <PostingCard v-for="posting in postings" :key="posting.id" :posting="posting" />
     </div>

--- a/app/plugins/setup-state.ts
+++ b/app/plugins/setup-state.ts
@@ -3,7 +3,7 @@ export default defineNuxtPlugin(async () => {
   const onboardingStatus = useOnboardingStatusState();
   const careerSiteConfigObjectState = useCareerSiteConfigObjectState();
   const seoConfigObjectState = useSeoConfigObjectState();
-  const totalPositionsState = usePositionState();
+  const totalPositionsState = useTotalPositionsState();
 
   try {
     const publicConfigRequest = await useFetch('/api/public/config');

--- a/app/plugins/setup-state.ts
+++ b/app/plugins/setup-state.ts
@@ -3,6 +3,7 @@ export default defineNuxtPlugin(async () => {
   const onboardingStatus = useOnboardingStatusState();
   const careerSiteConfigObjectState = useCareerSiteConfigObjectState();
   const seoConfigObjectState = useSeoConfigObjectState();
+  const totalPositionsState = usePositionState();
 
   try {
     const publicConfigRequest = await useFetch('/api/public/config');
@@ -13,6 +14,7 @@ export default defineNuxtPlugin(async () => {
 
     remoteAssetBase.value = pubicConfig.remoteAssetBase;
     onboardingStatus.value = pubicConfig.onboardingStatus;
+    totalPositionsState.value = pubicConfig.totalPositions;
     careerSiteConfigObjectState.setData(pubicConfig.settings.careerSite);
     seoConfigObjectState.setData(pubicConfig.settings.seo);
   } catch (error) {

--- a/app/plugins/setup-state.ts
+++ b/app/plugins/setup-state.ts
@@ -3,20 +3,20 @@ export default defineNuxtPlugin(async () => {
   const onboardingStatus = useOnboardingStatusState();
   const careerSiteConfigObjectState = useCareerSiteConfigObjectState();
   const seoConfigObjectState = useSeoConfigObjectState();
-  const totalPositionsState = useTotalPositionsState();
+  const totalActivePostings = useTotalActivePostingsState();
 
   try {
     const publicConfigRequest = await useFetch('/api/public/config');
     if (!publicConfigRequest.data.value) {
       throw new Error('config not received in response ' + publicConfigRequest.data.value);
     }
-    const pubicConfig = publicConfigRequest.data.value;
+    const publicConfig = publicConfigRequest.data.value;
 
-    remoteAssetBase.value = pubicConfig.remoteAssetBase;
-    onboardingStatus.value = pubicConfig.onboardingStatus;
-    totalPositionsState.value = pubicConfig.totalPositions;
-    careerSiteConfigObjectState.setData(pubicConfig.settings.careerSite);
-    seoConfigObjectState.setData(pubicConfig.settings.seo);
+    remoteAssetBase.value = publicConfig.remoteAssetBase;
+    onboardingStatus.value = publicConfig.onboardingStatus;
+    totalActivePostings.value = publicConfig.totalActivePostings;
+    careerSiteConfigObjectState.setData(publicConfig.settings.careerSite);
+    seoConfigObjectState.setData(publicConfig.settings.seo);
   } catch (error) {
     console.error('error fetching remote-asset-config', error);
   }

--- a/server/api/public/config.get.ts
+++ b/server/api/public/config.get.ts
@@ -4,7 +4,7 @@ import type { CareerSiteConfig, SEOConfig } from '~~/shared/schemas/setting';
 export default defineEventHandler(async () => {
   const remoteAssetBase = (await general_memoryStorage.getItem('remoteAssetBase')) as string;
   const onboardingStatus = !((await general_memoryStorage.getItem('firstSetupAccessKey')) as string);
-  const totalPositions = (await general_memoryStorage.getItem('totalPositions')) as number;
+  const totalActivePostings = (await general_memoryStorage.getItem('totalActivePostings')) as number;
 
   const settings = {
     careerSite: {},
@@ -14,5 +14,5 @@ export default defineEventHandler(async () => {
   settings.seo = (await settings_memoryStorage.getItem('seoConfig')) as SEOConfig;
   settings.careerSite = (await settings_memoryStorage.getItem('careerSiteConfig')) as CareerSiteConfig;
 
-  return { remoteAssetBase, onboardingStatus, totalPositions, settings };
+  return { remoteAssetBase, onboardingStatus, totalActivePostings, settings };
 });

--- a/server/api/public/config.get.ts
+++ b/server/api/public/config.get.ts
@@ -4,6 +4,7 @@ import type { CareerSiteConfig, SEOConfig } from '~~/shared/schemas/setting';
 export default defineEventHandler(async () => {
   const remoteAssetBase = (await general_memoryStorage.getItem('remoteAssetBase')) as string;
   const onboardingStatus = !((await general_memoryStorage.getItem('firstSetupAccessKey')) as string);
+  const totalPositions = (await general_memoryStorage.getItem('totalPositions')) as number;
 
   const settings = {
     careerSite: {},
@@ -13,5 +14,5 @@ export default defineEventHandler(async () => {
   settings.seo = (await settings_memoryStorage.getItem('seoConfig')) as SEOConfig;
   settings.careerSite = (await settings_memoryStorage.getItem('careerSiteConfig')) as CareerSiteConfig;
 
-  return { remoteAssetBase, onboardingStatus, settings };
+  return { remoteAssetBase, onboardingStatus, totalPositions, settings };
 });

--- a/server/utils/tasks/seed-cache.ts
+++ b/server/utils/tasks/seed-cache.ts
@@ -1,4 +1,4 @@
-import { desc, inArray } from 'drizzle-orm';
+import { desc, inArray, eq } from 'drizzle-orm';
 import { jobPostingsTable, reviewTagsTable, metaDataTable } from '~~/server/db/schema';
 import type { CareerSiteConfig, SEOConfig } from '~~/shared/schemas/setting';
 
@@ -19,6 +19,13 @@ export async function seedCache() {
     ...p,
     totalApplicants: -1,
   }));
+
+  const activePostings = await db
+    .select({ totalApplicants: jobPostingsTable.totalApplicants })
+    .from(jobPostingsTable)
+    .where(eq(jobPostingsTable.isPublished, true));
+
+  const totalActivePostings = activePostings.length;
 
   const settings = {
     careerSite: {},
@@ -44,6 +51,7 @@ export async function seedCache() {
     general_memoryStorage.setItem('remoteAssetBase', remoteAssetBase),
     general_memoryStorage.setItem('postings', jobPostings),
     general_memoryStorage.setItem('reviewTags', reviewTags),
+    general_memoryStorage.setItem('totalPositions', totalActivePostings),
   ]);
 
   return { result: true };

--- a/server/utils/tasks/seed-cache.ts
+++ b/server/utils/tasks/seed-cache.ts
@@ -1,4 +1,4 @@
-import { desc, inArray, eq } from 'drizzle-orm';
+import { desc, inArray, eq, count } from 'drizzle-orm';
 import { jobPostingsTable, reviewTagsTable, metaDataTable } from '~~/server/db/schema';
 import type { CareerSiteConfig, SEOConfig } from '~~/shared/schemas/setting';
 
@@ -20,12 +20,12 @@ export async function seedCache() {
     totalApplicants: -1,
   }));
 
-  const activePostings = await db
-    .select({ totalApplicants: jobPostingsTable.totalApplicants })
-    .from(jobPostingsTable)
-    .where(eq(jobPostingsTable.isPublished, true));
-
-  const totalActivePostings = activePostings.length;
+  const totalActivePostings = (
+    await db
+      .select({ count: count(jobPostingsTable.id) })
+      .from(jobPostingsTable)
+      .where(eq(jobPostingsTable.isPublished, true))
+  )[0].count;
 
   const settings = {
     careerSite: {},
@@ -51,7 +51,7 @@ export async function seedCache() {
     general_memoryStorage.setItem('remoteAssetBase', remoteAssetBase),
     general_memoryStorage.setItem('postings', jobPostings),
     general_memoryStorage.setItem('reviewTags', reviewTags),
-    general_memoryStorage.setItem('totalPositions', totalActivePostings),
+    general_memoryStorage.setItem('totalActivePostings', totalActivePostings),
   ]);
 
   return { result: true };

--- a/server/utils/tasks/seed-cache.ts
+++ b/server/utils/tasks/seed-cache.ts
@@ -20,12 +20,13 @@ export async function seedCache() {
     totalApplicants: -1,
   }));
 
-  const totalActivePostings = (
-    await db
-      .select({ count: count(jobPostingsTable.id) })
-      .from(jobPostingsTable)
-      .where(eq(jobPostingsTable.isPublished, true))
-  )[0].count;
+  const totalActivePostings =
+    (
+      await db
+        .select({ count: count(jobPostingsTable.id) })
+        .from(jobPostingsTable)
+        .where(eq(jobPostingsTable.isPublished, true))
+    )[0]?.count || 0;
 
   const settings = {
     careerSite: {},


### PR DESCRIPTION
##total-postions-addition-public-config-api-UI

##API update and Ui addition


## Changes performed

 - Updated the seedcache.ts to include total positions in "general memory storage" from "job postings" table
 -  Update the '/api/public/config' to include total positions in the api response fetching from general storage
 -  Updated the setup-state.ts file to include the total positions in the state value "totalPositionsState"
 -  Included the value in the UI index.vue beside "open positions"

[Attach screenshots or videos demonstrating the new feature in action.]
![image](https://github.com/user-attachments/assets/dbad9325-461e-4c4a-a908-2681aeec6aac)


## Issue Link
https://github.com/profilecity/vidur/issues/126

## Acceptance Criteria
The number of open positions is displayed next to the "Open Positions" header.
Total positions should be taken from cache (general_memoryStorage).
The counter updates automatically when job positions are added, edited, or removed (integrate update in endpoint).
The display should follow the format: "Open Positions (X)", where X is the number of positions.