### PR TITLE
fix(docker): missing db host from environment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -23,7 +23,7 @@ services:
       - .env
     environment:
       PORT: ${PORT:-3001}
-      NUXT_DB_HOST: db
+      NUXT_DB_HOST: ${NUXT_DB_HOST:-db}
       NUXT_DB_PORT: 5432
       NUXT_DB_USER: ${NUXT_DB_USER:-postgres}
       NUXT_DB_PASSWORD: ${NUXT_DB_PASSWORD:-postgrespw}


### PR DESCRIPTION
if you are connection with `neon` then see how to enable ssl mode- https://neon.tech/docs/connect/connect-securely

fixes: #239 